### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
     "bluebird": "^3.0.5",
     "intel": "^1.0.2",
     "lodash": "3.10.1",
-    "node-uuid": "1.4.7",
     "request": "2.67.0",
-    "tough-cookie-filestore": "github:imposibrus/tough-cookie-filestore"
+    "tough-cookie-filestore": "github:imposibrus/tough-cookie-filestore",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.1.4",

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import crypto from 'crypto';
 import {Readable as Readable} from 'stream';
 
 import Promise from 'bluebird';
-import uuid from 'node-uuid';
+import uuid from 'uuid';
 import request from 'request';
 import FileCookieStore from 'tough-cookie-filestore';
 import _ from 'lodash';


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.